### PR TITLE
rename Console to Interpreter (due to conflict with scala.Console, derp)

### DIFF
--- a/src/main/scala/com/twitter/scaffold/Interpreter.scala
+++ b/src/main/scala/com/twitter/scaffold/Interpreter.scala
@@ -2,14 +2,14 @@ package com.twitter.scaffold
 
 import akka.actor.{ Actor, Props }
 
-class Console extends Actor {
-  import Console._
+class Interpreter extends Actor {
+  import Interpreter._
 
   import java.io.ByteArrayOutputStream
   import scala.tools.nsc._
-  import interpreter._
+  import scala.tools.nsc.interpreter._
 
-  private[this] val console = new IMain({
+  private[this] val interpreter = new IMain({
     val settings = new Settings
     settings.usejavacp.value = true
     settings
@@ -18,20 +18,20 @@ class Console extends Actor {
   def receive = {
     case Interpret(expression) =>
       val out = new ByteArrayOutputStream
-      val result = scala.Console.withOut(out) { console.interpret(expression) }
+      val result = Console.withOut(out) { interpreter.interpret(expression) }
       val response = result match {
         case Results.Success => Success(out.toString)
         case Results.Error | Results.Incomplete => Failure(out.toString)
       }
       sender ! response
     case Reset =>
-      console.reset()
+      interpreter.reset()
   }
 }
 
-object Console {
+object Interpreter {
 
-  val props = Props[Console]
+  val props = Props[Interpreter]
 
   // requests
   case class Interpret(expression: String)

--- a/src/main/scala/com/twitter/scaffold/Scaffold.scala
+++ b/src/main/scala/com/twitter/scaffold/Scaffold.scala
@@ -8,8 +8,8 @@ import spray.routing.HttpService
 
 class Scaffold extends Actor with HttpService {
 
-  // TODO #6: there should be many console actors supervised by Scaffold, one per user session
-  val console = context.actorOf(Console.props, "console")
+  // TODO #6: there should be many interpreter actors supervised by Scaffold, one per user session
+  val interpreter = context.actorOf(Interpreter.props, "interpreter")
 
   /* HttpService */
   override val actorRefFactory = context
@@ -42,15 +42,15 @@ class Scaffold extends Actor with HttpService {
     post {
       import com.twitter.spray._
       entity(as[String]) {
-        Console.Interpret(_) ~> console ~> {
-          case Console.Success(message) => complete { message }
-          case Console.Failure(message) => respondWithStatus(BadRequest) { complete { message } }
+        Interpreter.Interpret(_) ~> interpreter ~> {
+          case Interpreter.Success(message) => complete { message }
+          case Interpreter.Failure(message) => respondWithStatus(BadRequest) { complete { message } }
         }
       }
     } ~
     delete {
       complete {
-        console ! Console.Reset
+        interpreter ! Interpreter.Reset
         NoContent
       }
     }


### PR DESCRIPTION
It's pretty common to do stuff like `Console.withOut` or `Console.err.println` or whatever... Which doesn't work if you have your own class named `Console` :poop:
